### PR TITLE
Add configurable map settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Maldives Islands
+
+This Django app provides Maldives atoll and island data along with a helper
+utility for generating Google static map previews.
+
+### Map preview defaults
+
+You can customise the map generation by setting the following settings in your
+project. If any are omitted the defaults shown here will be used.
+
+```python
+MAPS_ZOOM = 15
+MAPS_WIDTH = 600
+MAPS_HEIGHT = 300
+```
+

--- a/src/islandsmv/models.py
+++ b/src/islandsmv/models.py
@@ -33,12 +33,24 @@ class Island(models.Model):
     def lat_long_combined(self):
         return self.latitude, self.longitude
 
-    def get_static_map_url(self, zoom: int = 15, size: tuple[int, int] = (600, 300)) -> str:
+    def get_static_map_url(
+        self,
+        zoom: int | None = None,
+        size: tuple[int, int] | None = None,
+    ) -> str:
         """Return a signed Google Static Map preview URL for this island."""
         if not getattr(settings, "MAPS_API_KEY", None) or not getattr(settings, "MAPS_PRIVATE_KEY", None):
             raise RuntimeError("MAPS_API_KEY and MAPS_PRIVATE_KEY must be set to generate map previews")
 
         lat, lng = self.lat_long_combined
+
+        if zoom is None:
+            zoom = getattr(settings, "MAPS_ZOOM", 15)
+        if size is None:
+            width = getattr(settings, "MAPS_WIDTH", 600)
+            height = getattr(settings, "MAPS_HEIGHT", 300)
+            size = (width, height)
+
         key = settings.MAPS_API_KEY
         base = (
             "https://maps.googleapis.com/maps/api/staticmap"

--- a/src/islandsmv/tests.py
+++ b/src/islandsmv/tests.py
@@ -24,6 +24,29 @@ class StaticMapURLTests(TestCase):
         self.assertIn(str(island.latitude), url)
         self.assertIn(str(island.longitude), url)
 
+    @override_settings(
+        MAPS_API_KEY="key",
+        MAPS_PRIVATE_KEY="secret",
+        MAPS_ZOOM=10,
+        MAPS_WIDTH=400,
+        MAPS_HEIGHT=200,
+    )
+    def test_defaults_can_be_overridden_via_settings(self):
+        atoll = Atoll.objects.create(code="MLE")
+        island = Island.objects.create(
+            name="Vilimale",
+            island_name="vilimale",
+            atoll=atoll,
+            type=Island.MAALE[0],
+            longitude=73.48527944,
+            latitude=4.173394722,
+        )
+
+        url = island.get_static_map_url()
+
+        self.assertIn("&zoom=10", url)
+        self.assertIn("&size=400x200", url)
+
 
 class MissingKeyTests(TestCase):
     def test_get_static_map_url_without_credentials_raises(self):


### PR DESCRIPTION
## Summary
- make map generation use settings-based zoom/size defaults
- document new defaults in README
- ensure map defaults can be overridden via settings in tests

## Testing
- `uv sync` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684cf16b6c9c83259ca9f94d340f9d3b